### PR TITLE
Fix commands not executing on Windows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: Go
+name: Go CI
 
 on:
   push:

--- a/spawner.go
+++ b/spawner.go
@@ -22,7 +22,7 @@ type spawner map[string][]string
 var (
 	windowsSpawner = spawner{
 		"cmd":  {"powershell.exe -Command"},
-		"pwsh": {"powershell -command"},
+		"pwsh": {"powershell -Command"},
 	}
 	macSpawner = spawner{
 		"bash": {"-c"},

--- a/spawner.go
+++ b/spawner.go
@@ -40,7 +40,7 @@ func (s spawner) CreateCommand(cmd string, args string) (*exec.Cmd, error) {
 	if err != nil {
 		return nil, err
 	}
-	return exec.Command(spawnCmd, append(s[spawnCmd], " \""+args+"\"")...), nil
+	return exec.Command(spawnCmd, append(s[spawnCmd], args)...), nil
 }
 
 // getAvaiableSpawnCommand gets the first available spawn command. It returns

--- a/spawner.go
+++ b/spawner.go
@@ -21,7 +21,7 @@ type spawner map[string][]string
 
 var (
 	windowsSpawner = spawner{
-		"cmd":  {"powershell -Command"},
+		"cmd":  {"\\C powershell -Command"},
 		"pwsh": {"powershell -Command"},
 	}
 	macSpawner = spawner{
@@ -40,7 +40,7 @@ func (s spawner) CreateCommand(cmd string, args string) (*exec.Cmd, error) {
 	if err != nil {
 		return nil, err
 	}
-	return exec.Command(spawnCmd, append(s[spawnCmd], "\""+args+"\"")...), nil
+	return exec.Command(spawnCmd, append(s[spawnCmd], " \""+args+"\"")...), nil
 }
 
 // getAvaiableSpawnCommand gets the first available spawn command. It returns

--- a/spawner.go
+++ b/spawner.go
@@ -40,7 +40,12 @@ func (s spawner) CreateCommand(cmd string, args string) (*exec.Cmd, error) {
 	if err != nil {
 		return nil, err
 	}
-	return exec.Command(spawnCmd, append(s[spawnCmd], args)...), nil
+
+	if runtime.GOOS == "windows" {
+		return exec.Command("cmd", "/C", "powershell", "-Command", args), nil
+	}
+
+	return exec.Command(spawnCmd, append(s[spawnCmd], " \""+args+"\"")...), nil
 }
 
 // getAvaiableSpawnCommand gets the first available spawn command. It returns

--- a/spawner.go
+++ b/spawner.go
@@ -21,8 +21,8 @@ type spawner map[string][]string
 
 var (
 	windowsSpawner = spawner{
-		"cmd":  {"powershell -Command"},
-		"pwsh": {"powershell -Command"},
+		"cmd":  {"powershell.exe -Command"},
+		"pwsh": {"powershell -command"},
 	}
 	macSpawner = spawner{
 		"bash": {"-c"},

--- a/spawner.go
+++ b/spawner.go
@@ -21,7 +21,7 @@ type spawner map[string][]string
 
 var (
 	windowsSpawner = spawner{
-		"cmd":  {"powershell.exe -Command"},
+		"cmd":  {"powershell -Command"},
 		"pwsh": {"powershell -Command"},
 	}
 	macSpawner = spawner{
@@ -47,6 +47,11 @@ func (s spawner) CreateCommand(cmd string, args string) (*exec.Cmd, error) {
 // an error if no command is available.
 func (s spawner) getAvaiableSpawnCommand() (string, error) {
 	var cmd string
+
+	if runtime.GOOS == "windows" {
+		return "cmd", nil
+	}
+
 	for k := range s {
 		if _, err := exec.LookPath(k); err != nil {
 			continue

--- a/spawner.go
+++ b/spawner.go
@@ -21,7 +21,7 @@ type spawner map[string][]string
 
 var (
 	windowsSpawner = spawner{
-		"cmd":  {"\\C powershell -Command"},
+		"cmd":  {"/C powershell -Command"},
 		"pwsh": {"powershell -Command"},
 	}
 	macSpawner = spawner{

--- a/spawner.go
+++ b/spawner.go
@@ -21,8 +21,7 @@ type spawner map[string][]string
 
 var (
 	windowsSpawner = spawner{
-		"cmd":  {"/C powershell -Command"},
-		"pwsh": {"powershell -Command"},
+		"cmd": {"/C", "powershell", "-Command"},
 	}
 	macSpawner = spawner{
 		"bash": {"-c"},
@@ -35,27 +34,19 @@ var (
 )
 
 // CreateCommand creates an exec.Cmd that is prepared with the root command.
-func (s spawner) CreateCommand(cmd string, args string) (*exec.Cmd, error) {
+func (s spawner) CreateCommand(args string) (*exec.Cmd, error) {
 	spawnCmd, err := s.getAvaiableSpawnCommand()
 	if err != nil {
 		return nil, err
 	}
 
-	if runtime.GOOS == "windows" {
-		return exec.Command("cmd", "/C", "powershell", "-Command", args), nil
-	}
-
-	return exec.Command(spawnCmd, append(s[spawnCmd], " \""+args+"\"")...), nil
+	return exec.Command(spawnCmd, append(s[spawnCmd], args)...), nil
 }
 
 // getAvaiableSpawnCommand gets the first available spawn command. It returns
 // an error if no command is available.
 func (s spawner) getAvaiableSpawnCommand() (string, error) {
 	var cmd string
-
-	if runtime.GOOS == "windows" {
-		return "cmd", nil
-	}
 
 	for k := range s {
 		if _, err := exec.LookPath(k); err != nil {

--- a/subprocess.go
+++ b/subprocess.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 )
 
 // Subprocess represents a monitored process executed by the application.
@@ -48,9 +47,7 @@ func (s *Subprocess) Start(cmdStr string) error {
 		return fmt.Errorf("operating system %s not found", osName)
 	}
 
-	t := strings.Split(cmdStr, " ")
-
-	cmd, err := spawner.CreateCommand(t[0], strings.Join(t[0:], " "))
+	cmd, err := spawner.CreateCommand(cmdStr)
 	if err != nil {
 		return err
 	}

--- a/subprocess_test.go
+++ b/subprocess_test.go
@@ -1,7 +1,6 @@
 package subprocess_test
 
 import (
-	"fmt"
 	"os"
 	"runtime"
 	"testing"
@@ -21,8 +20,6 @@ func TestSubprocess(t *testing.T) {
 	var opts []subprocess.Option
 	if val, _ := os.LookupEnv("SHOW_TEST_SUBPROCESS_OUTPUT"); val != "true" {
 		opts = append(opts, subprocess.HideOutput)
-	} else {
-		fmt.Printf("GOOS: %s", runtime.GOOS)
 	}
 
 	sp := subprocess.New(opts...)

--- a/subprocess_test.go
+++ b/subprocess_test.go
@@ -1,6 +1,7 @@
 package subprocess_test
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 	"testing"
@@ -12,7 +13,7 @@ func TestSubprocess(t *testing.T) {
 	var cmdStr string
 
 	if runtime.GOOS == "windows" {
-		cmdStr = "Write-Host Hello world!"
+		cmdStr = "dir"
 	} else {
 		cmdStr = "ls"
 	}
@@ -20,6 +21,8 @@ func TestSubprocess(t *testing.T) {
 	var opts []subprocess.Option
 	if val, _ := os.LookupEnv("SHOW_TEST_SUBPROCESS_OUTPUT"); val != "true" {
 		opts = append(opts, subprocess.HideOutput)
+	} else {
+		fmt.Printf("GOOS: %s", runtime.GOOS)
 	}
 
 	sp := subprocess.New(opts...)


### PR DESCRIPTION
Commands do not execute Windows using `powershell` from `cmd.exe`.

This branch is for running the subprocess tests on each platform with logging enabled to ensure that commands work properly on all platforms.